### PR TITLE
🎉 PR 18 : suppress summary comment when all resolutions are cached

### DIFF
--- a/scripts/auto-resolve-reviews.js
+++ b/scripts/auto-resolve-reviews.js
@@ -518,9 +518,8 @@ async function main() {
     const resolvedCount = results.resolved.length;
     // Condition to skip posting:
     // 1. No resolutions found (resolvedCount === 0)
-    // 2. No API calls were made (apiCalls === 0)
-    // 3. All analyzed items came from cache (totalAnalyzed === cacheHits)
-    const shouldSkipSummary = resolvedCount === 0 && apiCalls === 0 && totalAnalyzed === cacheHits;
+    // 2. All analyzed items came from cache (totalAnalyzed === cacheHits)
+    const shouldSkipSummary = resolvedCount === 0 && totalAnalyzed === cacheHits;
 
     if (shouldSkipSummary) {
       console.log('✨ Skipping summary comment (No resolutions, all cached, no API calls).');


### PR DESCRIPTION
<!-- USER_CONTENT_START -->
This PR modifies the auto-resolution script to prevent posting an empty summary comment when no resolutions were made and all analysis was served from the cache.
<!-- USER_CONTENT_END -->
<!-- AUTO_GENERATED_START -->
## 📁 Changed files
```
└── scripts/
└── auto-resolve-reviews.js (+18/-8)
```
## 📊 Stats
| Metric | Value |
|--------|------:|
| Files changed | 1 |
| Lines added | +18 |
| Lines deleted | -8 |
| Commits | 2 |
## 📝 Commits
- `d6629ae` – chore: suppress summary comment when all resolutions are cached
- `d2ac308` – 😤 Simplify condition
<!-- AUTO_GENERATED_END -->
