### PR TITLE
🎉 PR 31 : Add PR merge readiness check workflow

### DIFF
--- a/.github/workflows/pr-merge-check.yml
+++ b/.github/workflows/pr-merge-check.yml
@@ -1,0 +1,32 @@
+name: PR Merge Readiness Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-merge-readiness:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check for 'status: fixed' label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+
+            const labels = pr.labels.map(label => label.name);
+            const hasFixedLabel = labels.includes('status: fixed');
+
+            core.notice(`PR labels: ${labels.join(', ')}`);
+
+            if (hasFixedLabel) {
+              core.notice('✅ PR is ready to merge - "status: fixed" label is present');
+            } else {
+              core.setFailed('❌ PR is not ready to merge - "status: fixed" label is missing');
+            }

--- a/.github/workflows/pr-merge-check.yml
+++ b/.github/workflows/pr-merge-check.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Check for 'status: fixed' label
+      - name: "Check for 'status: fixed' label"
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
<!-- USER_CONTENT_START -->
Add a GitHub Actions workflow that acts as a merge gate check for pull requests. The check passes only when the 'status: fixed' label is present on the PR, otherwise it fails. This ensures PRs are not merged until they are properly marked as fixed.
Triggers on: opened, reopened, synchronize, labeled, unlabeled
<!-- USER_CONTENT_END -->
<!-- RELATED_ISSUES_START -->
## 🔗 Related issues
Link any related issues or PRs that provide context for this change.
- Closes: <!-- e.g. #123 -->
- Relates to: <!-- e.g. #456 -->
<!-- RELATED_ISSUES_END -->
<!-- AUTO_GENERATED_START -->
## 📁 Changed files
```
└── .github/
└── workflows/
└── pr-merge-check.yml (+26/-0)
```
## 📊 Stats
| Metric | Value |
|--------|------:|
| Files changed | 1 |
| Lines added | +26 |
| Lines deleted | -0 |
| Commits | 4 |
## 📝 Commits
- `addbf03` – ✅ Add PR merge readiness check workflow
- `b91a601` – 🐛 Fix YAML syntax error in pr-merge-check workflow
- `bb79920` – Unnecessary PR data
- `befb054` – Fix review-needed label stauts
<!-- AUTO_GENERATED_END -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions merge gate for PRs.
> 
> - New workflow `/.github/workflows/pr-merge-check.yml` triggers on PR events (`opened`, `reopened`, `synchronize`, `labeled`, `unlabeled`)
> - Uses `actions/github-script@v7` to read PR labels and log them
> - Succeeds only if `status: review-needed` label is present; otherwise fails the check
> - Scoped permission `pull-requests: read`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit befb054c90bef4ebd66cc333558c850c2e2a74a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->